### PR TITLE
Bare metal targets

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,7 +10,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  build-and-test:
     runs-on: ubuntu-latest
 
     steps:
@@ -25,30 +25,34 @@ jobs:
         components: rustfmt, clippy
         override: true
 
+    - name: Run Clippy
+      run: cargo clippy --all-targets --all-features -- -D warnings
+
     - name: Build
       run: cargo build --lib --verbose
 
-    - name: Run tests
+    - name: Run basic tests
       run: cargo test --verbose
 
     - name: Run extensive tests
       run: cargo test --release --verbose -- --ignored
 
-    - name: Run Clippy
-      run: cargo clippy --all-targets --all-features -- -D warnings
-
     - name: Check formatting
       run: cargo fmt -- --check
 
-    # - name: Install tarpaulin
-    #   run: cargo install cargo-tarpaulin
+  x86_64-unknown-none:
+    runs-on: ubuntu-latest
 
-    # - name: Generate code coverage
-    #   run: |
-    #     cargo tarpaulin --out Xml
-    #     bash <(curl -s https://codecov.io/bash) -f lcov.info
+    steps:
+    - uses: actions/checkout@v3
 
-    # - name: Security audit
-    #   run: cargo install cargo-audit
-    # - name: Run security audit
-    #   run: cargo audit
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        target: x86_64-unknown-none
+        profile: minimal
+        override: true
+
+    - name: Build
+      run: cargo build --lib --verbose

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,7 @@ dependencies = [
 name = "homomorph"
 version = "1.0.0"
 dependencies = [
+ "getrandom",
  "mimalloc",
  "rand",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-mimalloc = "0.1.43"
 rand = "0.8.5"
+
+[dev-dependencies]
+mimalloc = "0.1.43"
 
 [profile.release]
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,11 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rand = "0.8.5"
+getrandom = { version = "0.2.15", default-features = false, features = ["rdrand"] }
 
 [dev-dependencies]
 mimalloc = "0.1.43"
+rand = "0.8.5"
 
 [profile.release]
 codegen-units = 1

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ I do not intend to publish the crate on `crates.io`.
 
 ## Benchmarks
 
-Benchmarks were made using a Ryzen 7 7800x3D on Windows 11 by averaging on 1 000 tries on `u32`.
+Benchmarks were made using a Ryzen 7 7800x3D on Windows 11 by averaging on 1 000 tries on `u32` using `mimalloc`.
 
 Parameters used for this benchmark were :
 - `d` = 128

--- a/examples/uint_add.rs
+++ b/examples/uint_add.rs
@@ -20,12 +20,8 @@ fn main() {
     let pk = context.get_public_key().unwrap();
 
     // Generate random data
-    let data1: Vec<_> = (0..NUMBER_OF_TESTS)
-        .map(|_| rng.gen::<u32>() / 2)
-        .collect();
-    let data2: Vec<_> = (0..NUMBER_OF_TESTS)
-        .map(|_| rng.gen::<u32>() / 2)
-        .collect();
+    let data1: Vec<_> = (0..NUMBER_OF_TESTS).map(|_| rng.gen::<u32>() / 2).collect();
+    let data2: Vec<_> = (0..NUMBER_OF_TESTS).map(|_| rng.gen::<u32>() / 2).collect();
 
     // Encrypt the data
     let start = Instant::now();

--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -1,6 +1,7 @@
 use crate::polynomial::Polynomial;
 use crate::{PublicKey, SecretKey};
 
+use alloc::vec::Vec;
 use core::ops::Deref;
 use core::ptr::copy_nonoverlapping as memcpy;
 use rand::Rng;

--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -4,7 +4,6 @@ use crate::{PublicKey, SecretKey};
 use alloc::vec::Vec;
 use core::ops::Deref;
 use core::ptr::copy_nonoverlapping as memcpy;
-use rand::Rng;
 
 /// This trait is used to convert a type to a byte array and back
 ///
@@ -89,11 +88,12 @@ impl<T: ByteConvertible> Ciphered<T> {
     // u8 is used instead of bool because they are the same size
     // while u8 can store 8 times more information
     fn part(tau: usize) -> Vec<u8> {
-        let mut rng = rand::thread_rng();
-        let mut part: Vec<u8> = Vec::with_capacity((tau + 7) / 8);
+        let num_elements = (tau + 7) / 8;
+        let mut part: Vec<u8> = Vec::with_capacity(num_elements);
 
-        for _ in 0..(tau + 7) / 8 {
-            part.push(rng.gen());
+        unsafe {
+            getrandom::getrandom(&mut part).unwrap();
+            part.set_len(num_elements);
         }
 
         part

--- a/src/context.rs
+++ b/src/context.rs
@@ -121,7 +121,7 @@ impl SecretKey {
     }
 
     pub(self) fn random(d: usize) -> Self {
-        let s = polynomial::Polynomial::random(d, &mut rand::thread_rng());
+        let s = polynomial::Polynomial::random(d);
         SecretKey { s }
     }
 
@@ -220,9 +220,9 @@ impl PublicKey {
     pub(self) fn random(dp: usize, delta: usize, tau: usize, secret_key: &SecretKey) -> Self {
         let list: Vec<_> = (0..tau)
             .map(|_| {
-                let q = polynomial::Polynomial::random(dp, &mut rand::thread_rng());
+                let q = polynomial::Polynomial::random(dp);
                 let sq = secret_key.s.clone().mul(&q);
-                let r = polynomial::Polynomial::random(delta, &mut rand::thread_rng());
+                let r = polynomial::Polynomial::random(delta);
                 // TODO: Simplify multiplication by X (shift)
                 let rx = r.mul(&polynomial::Polynomial::monomial(1));
                 sq.add(&rx)

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,6 +1,7 @@
 use crate::polynomial;
 
-use std::ops::Deref;
+use alloc::vec::Vec;
+use core::ops::Deref;
 
 /// Parameters for the algorithm.
 ///
@@ -222,7 +223,8 @@ impl PublicKey {
                 let q = polynomial::Polynomial::random(dp, &mut rand::thread_rng());
                 let sq = secret_key.s.clone().mul(&q);
                 let r = polynomial::Polynomial::random(delta, &mut rand::thread_rng());
-                let rx = r.mul(&unsafe { polynomial::Polynomial::new_unchecked(vec![0b10], 1) });
+                // TODO: Simplify multiplication by X (shift)
+                let rx = r.mul(&polynomial::Polynomial::monomial(1));
                 sq.add(&rx)
             })
             .collect();

--- a/src/impls/numbers/uint.rs
+++ b/src/impls/numbers/uint.rs
@@ -52,8 +52,6 @@ impl_homomorphic_addition_uint!(u8, u16, u32, usize, u64, u128);
 
 #[cfg(test)]
 mod tests {
-    use rand::{thread_rng, Rng};
-
     use crate::cipher::HomomorphicOperation;
     use crate::Ciphered;
     use crate::HomomorphicAddition;
@@ -74,8 +72,16 @@ mod tests {
         let d = c.decipher(sk);
         assert_eq!(d, 42);
 
-        let a_raw = thread_rng().gen::<u16>() / 2;
-        let b_raw = thread_rng().gen::<u16>() / 2;
+        let a_raw = {
+            let mut buffer = [0u8; 2];
+            getrandom::getrandom(&mut buffer).expect("Failed to generate random bytes");
+            u16::from_le_bytes(buffer)
+        } / 2;
+        let b_raw = {
+            let mut buffer = [0u8; 2];
+            getrandom::getrandom(&mut buffer).expect("Failed to generate random bytes");
+            u16::from_le_bytes(buffer)
+        } / 2;
 
         let a = Ciphered::cipher(&a_raw, pk);
         let b = Ciphered::cipher(&b_raw, pk);
@@ -94,8 +100,16 @@ mod tests {
         let pk = context.get_public_key().unwrap();
         let sk = context.get_secret_key().unwrap();
 
-        let a_raw = thread_rng().gen::<usize>() / 2;
-        let b_raw = thread_rng().gen::<usize>() / 2;
+        let a_raw = {
+            let mut buffer = [0u8; 8];
+            getrandom::getrandom(&mut buffer).expect("Failed to generate random bytes");
+            u64::from_le_bytes(buffer)
+        } / 2;
+        let b_raw = {
+            let mut buffer = [0u8; 8];
+            getrandom::getrandom(&mut buffer).expect("Failed to generate random bytes");
+            u64::from_le_bytes(buffer)
+        } / 2;
 
         let a = Ciphered::cipher(&a_raw, pk);
         let b = Ciphered::cipher(&b_raw, pk);

--- a/src/impls/numbers/uint.rs
+++ b/src/impls/numbers/uint.rs
@@ -1,5 +1,7 @@
 use crate::{Ciphered, HomomorphicAddition, HomomorphicOperation, Polynomial};
 
+use alloc::vec::Vec;
+
 fn homomorph_add_internal(a: &[Polynomial], b: &[Polynomial]) -> Vec<Polynomial> {
     let longest = a.len().max(b.len());
     let mut result = Vec::with_capacity(longest + 1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,7 +121,7 @@
 //! The trait only bounds one function to implement, `apply`.
 //! The operation is performed on raw data, which means it takes `Ciphered<T>` as arguments.
 //!
-//! Inside of the function, you will have to work with `Cipehered<T>` as if it were a ``Vec<Polynomial>`
+//! Inside of the function, you will have to work with `Cipehered<T>` as if it were a `Vec<Polynomial>`
 //! (because this is actually what it is).
 //! From that point, all operations are highly unsafe as you are working with raw bits, represented as polynomials.
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,11 +231,11 @@ extern crate alloc;
 mod polynomial;
 pub use polynomial::Polynomial;
 
+mod context;
+pub use context::*;
+
 mod cipher;
 pub use cipher::*;
 
 mod impls;
 pub use impls::*;
-
-mod context;
-pub use context::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,6 +223,11 @@
 //! The source code is available on [GitHub](<https://github.com/mathisbot/homomorph-rust>).
 //! You will also find very interesting details on the system and its security.
 
+#![no_std]
+
+#[macro_use]
+extern crate alloc;
+
 mod polynomial;
 pub use polynomial::Polynomial;
 

--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+
 /// A polynomial over Z/2Z.
 ///
 /// A polynomial is represented as a vector of coefficients.
@@ -214,6 +216,7 @@ impl Clone for Polynomial {
 #[cfg(test)]
 mod test {
     use super::Polynomial;
+    use alloc::vec::Vec;
 
     #[test]
     fn test_get_degree() {
@@ -223,14 +226,14 @@ mod test {
 
     #[test]
     fn test_new() {
-        let p = Polynomial::new(vec![0b10010]);
-        assert_eq!(p.degree, 4);
+        let p = Polynomial::new(vec![0b10010001]);
+        assert_eq!(p.degree, 7);
     }
 
     #[test]
     #[should_panic]
     fn test_new_panic() {
-        let _ = Polynomial::new(vec![]);
+        let _ = Polynomial::new(Vec::new());
     }
 
     #[test]
@@ -244,7 +247,7 @@ mod test {
     #[should_panic]
     fn test_new_unchecked_panic() {
         unsafe {
-            let _ = Polynomial::new_unchecked(vec![], 0);
+            let _ = Polynomial::new_unchecked(Vec::new(), 0);
         }
     }
 
@@ -268,6 +271,7 @@ mod test {
         let p2 = p1.clone();
         assert_eq!(p1.degree, p2.degree);
         assert_eq!(p1.coefficients, p2.coefficients);
+
         let p1 = Polynomial::new(vec![0b1001, 0b1000001101011010, 0b0, 0b1, 0b0]);
         let p2 = p1.clone();
         assert_eq!(p1.degree, p2.degree);


### PR DESCRIPTION
Makes the crate no_std compatible, and usable on `unknown-none` targets.